### PR TITLE
Fixed trailing slash in URL

### DIFF
--- a/src/Jira/Api.php
+++ b/src/Jira/Api.php
@@ -72,6 +72,9 @@ class Api
         AuthenticationInterface $authentication,
         ClientInterface $client = null
     ) {
+        //Regular expression to remove trailing slash
+        $endpoint = preg_replace('{/$}', '', $endpoint);
+        
         $this->setEndPoint($endpoint);
         $this->authentication = $authentication;
 


### PR DESCRIPTION
Added regular expression to remove trailing slash if included in URL. Api::__construct
